### PR TITLE
wallet backup docs

### DIFF
--- a/wallet/README.md
+++ b/wallet/README.md
@@ -26,3 +26,9 @@ The `wallet` application is now in `$HOME/go/bin/wallet`.
 You should only connect the wallet to a client peer you trust. A bad client can misbehave in all sorts of ways that could confuse your wallet and trick you into making transactions you otherwise wouldn't. You also expose which public keys you control to the peer.
 
 The prompt should be mostly self-documenting. Use the `newkey` command to generate a public/private key pair. The displayed public key can be used as the `-pubkey` argument to the [client program.](https://github.com/cruzbit/cruzbit/tree/master/client)
+
+## Backup
+
+To backup your private keys, make a copy of your `-walletdb` directory _after_ you've exited the `wallet` program.
+
+Later, you can restore your keys by simply starting the `wallet` and pointing `-walletdb` at this directory.


### PR DESCRIPTION
Add some documentation to the wallet's readme describing how to backup and restore keys.

https://github.com/cruzbit/cruzbit/issues/11