### PR TITLE
dnsseed: improve peer selection diversity

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -167,7 +167,7 @@ func main() {
 	// manage peer connections
 	peerManager := NewPeerManager(genesisID, peerStore, blockStore, ledger, processor, txQueue,
 		*dataDirPtr, myExternalIP, *peerPtr, *tlsCertPtr, *tlsKeyPtr,
-		*portPtr, *inLimitPtr, !*noAcceptPtr, !*noIrcPtr)
+		*portPtr, *inLimitPtr, !*noAcceptPtr, !*noIrcPtr, *dnsSeedPtr)
 	peerManager.Run()
 
 	// shutdown on ctrl-c

--- a/dns.go
+++ b/dns.go
@@ -36,8 +36,8 @@ func (d *DNSSeeder) handleQuery(m *dns.Msg, externalIP string) {
 	for _, q := range m.Question {
 		switch q.Qtype {
 		case dns.TypeA:
-			// get up to 32 peers that we've connected to in the last 48 hours
-			addresses, err := d.peerStore.GetSince(32, time.Now().Unix()-(60*60*48))
+			// get up to 128 peers that we've connected to in the last 48 hours
+			addresses, err := d.peerStore.GetSince(128, time.Now().Unix()-(60*60*48))
 			if err != nil {
 				log.Printf("Error requesting peers from storage: %s\n", err)
 				return

--- a/peer_storage_disk.go
+++ b/peer_storage_disk.go
@@ -9,6 +9,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"math"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -46,7 +47,7 @@ func (p *PeerStorageDisk) Store(addr string) (bool, error) {
 		return false, nil
 	}
 
-	info := peerInfo{FirstSeen: time.Now().Unix()}
+	info := peerInfo{FirstSeen: time.Now().Unix(), LastAttempt: rand.Int63n(1 << 30)}
 	batch := new(leveldb.Batch)
 	if err := info.writeToBatch(addr, batch); err != nil {
 		return false, err
@@ -352,7 +353,7 @@ type peerInfo struct {
 
 // Should we retry this connection?
 func (p peerInfo) shouldRetry() bool {
-	if p.LastAttempt == 0 {
+	if p.LastAttempt < 1<<30 {
 		// never been tried
 		return true
 	}

--- a/peer_storage_disk.go
+++ b/peer_storage_disk.go
@@ -47,6 +47,8 @@ func (p *PeerStorageDisk) Store(addr string) (bool, error) {
 		return false, nil
 	}
 
+	// insert new peers at the head of the list to try next but put them in a random position
+	// relative to other new peers
 	info := peerInfo{FirstSeen: time.Now().Unix(), LastAttempt: rand.Int63n(1 << 30)}
 	batch := new(leveldb.Batch)
 	if err := info.writeToBatch(addr, batch); err != nil {


### PR DESCRIPTION
When running with `-dnsseed`:

* Periodically drop a random outbound peer connection so that we attempt to try more peers
* Request more peers from the peer store to shuffle