### PR TITLE
cuda: hash the first (largest) part of the header only once

### DIFF
--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -6,5 +6,6 @@ set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}; -Xcompiler -fPIC)
 CUDA_ADD_LIBRARY(cruzbit_cuda SHARED
   mine.cu
   sha3.cu
+  sha3.cc
 )
 install(TARGETS cruzbit_cuda DESTINATION lib)

--- a/cuda/sha3.h
+++ b/cuda/sha3.h
@@ -1,9 +1,12 @@
 // sha3.h
 // 19-Nov-11  Markku-Juhani O. Saarinen <mjos@iki.fi>
+// Revised 21-Jul-19 to strip unneeded code and move sha3_ctx_t to its own file.
+// we need to build both a host and device version of this code. -asdvxgxasjab
 
-#ifndef SHA3_CU_H
-#define SHA3_CU_H
+#ifndef SHA3_H
+#define SHA3_H
 
+#include "sha3_ctx.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -15,25 +18,16 @@
 #define ROTL64(x, y) (((x) << (y)) | ((x) >> (64 - (y))))
 #endif
 
-// state context
-typedef struct {
-  union {           // state:
-    uint8_t b[200]; // 8-bit bytes
-    uint64_t q[25]; // 64-bit words
-  } st;
-  int pt, rsiz, mdlen; // these don't overflow
-} sha3_ctx_t;
-
 // Compression function.
-__device__ void sha3_keccakf(uint64_t st[25]);
+void sha3_keccakf(uint64_t st[25]);
 
 // OpenSSL - like interfece
-__device__ int sha3_init_cu(sha3_ctx_t *c,
-                            int mdlen); // mdlen = hash output in bytes
-__device__ int sha3_update_cu(sha3_ctx_t *c, const void *data, size_t len);
-__device__ int sha3_final_cu(void *md, sha3_ctx_t *c); // digest goes to md
+int sha3_init(sha3_ctx_t *c,
+              int mdlen); // mdlen = hash output in bytes
+int sha3_update(sha3_ctx_t *c, const void *data, size_t len);
+int sha3_final(void *md, sha3_ctx_t *c); // digest goes to md
 
 // compute a sha3 hash (md) of given byte length from "in"
-__device__ void *sha3_cu(const void *in, size_t inlen, void *md, int mdlen);
+void *sha3(const void *in, size_t inlen, void *md, int mdlen);
 
 #endif

--- a/cuda/sha3_ctx.h
+++ b/cuda/sha3_ctx.h
@@ -1,0 +1,20 @@
+// sha3_ctx.h
+// 19-Nov-11  Markku-Juhani O. Saarinen <mjos@iki.fi>
+// Revised 21-Jul-19 moved sha3_ctx_t to its own file -asdvxgxasjab
+
+#ifndef SHA3_CTX_H
+#define SHA3_CTX_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+// state context
+typedef struct {
+  union {           // state:
+    uint8_t b[200]; // 8-bit bytes
+    uint64_t q[25]; // 64-bit words
+  } st;
+  int pt, rsiz, mdlen; // these don't overflow
+} sha3_ctx_t;
+
+#endif

--- a/cuda/sha3_cu.h
+++ b/cuda/sha3_cu.h
@@ -1,0 +1,32 @@
+// sha3_cu.h
+// 19-Nov-11  Markku-Juhani O. Saarinen <mjos@iki.fi>
+// Revised 19-Jul-19 sha3.h to run on Nvidia devices -asdvxgxasjab
+
+#ifndef SHA3_CU_H
+#define SHA3_CU_H
+
+#include "sha3_ctx.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef KECCAKF_ROUNDS
+#define KECCAKF_ROUNDS 24
+#endif
+
+#ifndef ROTL64
+#define ROTL64(x, y) (((x) << (y)) | ((x) >> (64 - (y))))
+#endif
+
+// Compression function.
+__device__ void sha3_keccakf_cu(uint64_t st[25]);
+
+// OpenSSL - like interfece
+__device__ int sha3_init_cu(sha3_ctx_t *c,
+                            int mdlen); // mdlen = hash output in bytes
+__device__ int sha3_update_cu(sha3_ctx_t *c, const void *data, size_t len);
+__device__ int sha3_final_cu(void *md, sha3_ctx_t *c); // digest goes to md
+
+// compute a sha3 hash (md) of given byte length from "in"
+__device__ void *sha3_cu(const void *in, size_t inlen, void *md, int mdlen);
+
+#endif


### PR DESCRIPTION
On a 4 CPU Linux instance with 2 Tesla V100s I noticed a speed-up from ~460 MH/s to ~990 MH/s.