### PR TITLE
add checkpoints

### DIFF
--- a/checkpoints.go
+++ b/checkpoints.go
@@ -1,0 +1,36 @@
+// Copyright 2019 cruzbit developers
+// Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
+
+package cruzbit
+
+import (
+	"fmt"
+)
+
+// CheckpointsEnabled can be disabled for testing.
+const CheckpointsEnabled = true
+
+// LatestCheckpointHeight is used to determine if the client is synced.
+const LatestCheckpointHeight = 18144
+
+// Checkpoints are known height and block ID pairs on the main chain.
+var Checkpoints map[int64]string = map[int64]string{
+	18144: "000000000000b83e78ec29355d098256936389010d7450a288763ed4f191069e",
+}
+
+// CheckpointCheck returns an error if the passed height is a checkpoint and the
+// passed block ID does not match the given checkpoint block ID.
+func CheckpointCheck(id BlockID, height int64) error {
+	if !CheckpointsEnabled {
+		return nil
+	}
+	checkpointID, ok := Checkpoints[height]
+	if !ok {
+		return nil
+	}
+	if id.String() != checkpointID {
+		return fmt.Errorf("Block %s at height %d does not match checkpoint ID %s",
+			id, height, checkpointID)
+	}
+	return nil
+}

--- a/constants.go
+++ b/constants.go
@@ -3,12 +3,6 @@
 
 package cruzbit
 
-import (
-	"encoding/hex"
-	"math/big"
-	"sync"
-)
-
 // the below values affect ledger consensus and come directly from bitcoin.
 // we could have played with these but we're introducing significant enough changes
 // already IMO, so let's keep the scope of this experiment as small as we can
@@ -52,9 +46,6 @@ const MAX_MEMO_LENGTH = 100 // bytes (ascii/utf8 only)
 // given our JSON protocol we should respect Javascript's Number.MAX_SAFE_INTEGER value
 const MAX_NUMBER int64 = 1<<53 - 1
 
-// DoS prevention mechanism. this amount of work was reached as of height 18144
-const MIN_CHAIN_WORK = "0000000000000000000000000000000000000000000000000187af7c51ca9b26"
-
 // the below values only affect peering behavior and do not affect ledger consensus
 
 const DEFAULT_CRUZBIT_PORT = 8831
@@ -79,22 +70,3 @@ const MAX_TRANSACTION_QUEUE_LENGTH = MAX_TRANSACTIONS_TO_INCLUDE_PER_BLOCK * 10
 const MIN_FEE_CRUZBITS = 1000000 // 0.01 cruz
 
 const MIN_AMOUNT_CRUZBITS = 1000000 // 0.01 cruz
-
-// handle converting MIN_CHAIN_WORK to a big.Int
-var minChainWork *big.Int
-var minChainWorkLock sync.Mutex
-
-func GetMinChainWork() *big.Int {
-	if minChainWork == nil {
-		minChainWorkLock.Lock()
-		if minChainWork == nil {
-			minChainWorkBytes, err := hex.DecodeString(MIN_CHAIN_WORK)
-			if err != nil {
-				panic(err)
-			}
-			minChainWork = new(big.Int).SetBytes(minChainWorkBytes)
-		}
-		minChainWorkLock.Unlock()
-	}
-	return minChainWork
-}

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -775,7 +775,7 @@ func IsInitialBlockDownload(ledger Ledger, blockStore BlockStorage) (bool, int64
 	if tipHeader == nil {
 		return true, 0, nil
 	}
-	if tipHeader.ChainWork.GetBigInt().Cmp(GetMinChainWork()) < 0 {
+	if CheckpointsEnabled && tipHeader.Height < LatestCheckpointHeight {
 		return true, tipHeader.Height, nil
 	}
 	return tipHeader.Time < (time.Now().Unix() - MAX_TIP_AGE), tipHeader.Height, nil

--- a/processor.go
+++ b/processor.go
@@ -466,6 +466,11 @@ func checkBlock(id BlockID, block *Block, now int64) error {
 		return fmt.Errorf("Height value is invalid, block %s", id)
 	}
 
+	// check against known checkpoints
+	if err := CheckpointCheck(id, block.Header.Height); err != nil {
+		return err
+	}
+
 	// sanity check transaction count
 	if block.Header.TransactionCount < 0 {
 		return fmt.Errorf("Negative transaction count in header of block %s", id)


### PR DESCRIPTION
This is a slightly better protection than the minimum chain work change I added previously. With this change we won't process low difficulty blocks and we'll also make sure the protection doesn't kick-in until we're synced on the correct chain as of the latest checkpoint.