### PR TITLE
Use default port for peer if not provided

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/cruzbit/cruzbit"
@@ -181,6 +183,12 @@ func main() {
 		} else {
 			log.Println("Successfully enabled forwarding")
 		}
+	}
+
+	// add default port, if one was not supplied
+	i := strings.LastIndex(*peerPtr, ":")
+	if i < 0 {
+		*peerPtr = *peerPtr + ":" + strconv.Itoa(DEFAULT_CRUZBIT_PORT)
 	}
 
 	// manage peer connections

--- a/wallet/main.go
+++ b/wallet/main.go
@@ -44,6 +44,11 @@ func main() {
 	if len(*peerPtr) == 0 {
 		log.Fatal("Peer address required")
 	}
+	// add default port, if one was not supplied
+	i := strings.LastIndex(*peerPtr, ":")
+	if i < 0 {
+		*peerPtr = *peerPtr + ":" + strconv.Itoa(DEFAULT_CRUZBIT_PORT)
+	}
 
 	// load genesis block
 	var genesisBlock Block


### PR DESCRIPTION
Addresses #30 

Automatically appends DEFAULT_CRUZBIT_PORT to an address supplied to `-peer` if the input does not contain a colon character.