### PR TITLE
Add command to export pub/priv key pairs to file

### DIFF
--- a/wallet.go
+++ b/wallet.go
@@ -156,6 +156,24 @@ func (w *Wallet) GetKeys() ([]ed25519.PublicKey, error) {
 	return pubKeys, nil
 }
 
+// Retrieve a private key for a given public key
+func (w *Wallet) GetPrivateKey(pubKey ed25519.PublicKey) (ed25519.PrivateKey, error) {
+	// fetch the private key
+	privKeyDbKey, err := encodePrivateKeyDbKey(pubKey)
+	if err != nil {
+		return nil, err
+	}
+	encryptedPrivKey, err := w.db.Get(privKeyDbKey, nil)
+	if err != nil {
+		return nil, err
+	}
+	privKey, ok := decryptPrivateKey(encryptedPrivKey, w.passphrase)
+	if !ok {
+		return nil, fmt.Errorf("unable to decrypt private key")
+	}
+	return privKey, nil
+}
+
 // Connect connects to a peer for transaction history, balance information, and sending new transactions.
 // The threat model assumes the peer the wallet is speaking to is not an adversary.
 func (w *Wallet) Connect(addr string, genesisID BlockID, tlsVerify bool) error {

--- a/wallet/main.go
+++ b/wallet/main.go
@@ -169,6 +169,7 @@ func main() {
 			{Text: "clearconf", Description: "Clear all pending transaction confirmation notifications"},
 			{Text: "rewards", Description: "Show immature block rewards for all public keys"},
 			{Text: "verify", Description: "Verify the private key is decryptable and intact for all public keys displayed with 'listkeys'"},
+			{Text: "export", Description: "Save all of the wallet's public-private key pairs to a text file"},
 			{Text: "quit", Description: "Quit this wallet session"},
 		}
 		return prompt.FilterHasPrefix(s, d.GetWordBeforeCursor(), true)
@@ -454,6 +455,37 @@ func main() {
 			}
 			fmt.Printf("%d key(s) verified and %d key(s) potentially corrupt\n",
 				verified, corrupt)
+
+		case "export":
+			pubKeys, err := wallet.GetKeys()
+			if err != nil {
+				fmt.Printf("Error: %s\n", err)
+				break
+			}
+			if len(pubKeys) == 0 {
+				fmt.Printf("No private keys found\n")
+				break
+			}
+			name := "export.txt"
+			f, err := os.Create(name)
+			if err != nil {
+				fmt.Printf("Error: %s\n", err)
+				break
+			}
+			count := 0
+			for _, pubKey := range pubKeys {
+				private, err := wallet.GetPrivateKey(pubKey)
+				if err != nil {
+					break
+				}
+				pair := fmt.Sprintf("%s\n%s\n\n",
+					base64.StdEncoding.EncodeToString(pubKey[:]),
+					base64.StdEncoding.EncodeToString(private[:]))
+				f.WriteString(pair)
+				count += 1
+			}
+			f.Close()
+			fmt.Printf("%d wallet key pairs saved to '%s'\n", count, aurora.Bold(name))
 
 		case "quit":
 			wallet.Shutdown()


### PR DESCRIPTION
Giving the user the ability to export their private keys allows wallet portability between the reference client/wallet and other "third-party" wallets.

This feature is currently quite minimal, and doesn't display any warnings in favor of assuming users know the implications of creating copies of private keys. Further enhancements could include such warnings, or the ability to choose which of the available public keys to export.

(Corrects error in earlier pull request #46 )