### PR TITLE
Update constants.go

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -19,9 +19,9 @@ const MAX_FUTURE_SECONDS = 2 * 60 * 60 // 2 hours
 
 const MAX_MONEY = 21000000 * CRUZBITS_PER_CRUZ
 
-const RETARGET_INTERVAL = 2016 // 2 weeks in blocks
+const RETARGET_INTERVAL = 144 // 1 day in blocks
 
-const RETARGET_TIME = 1209600 // 2 weeks in seconds
+const RETARGET_TIME = 86400 // 1 day in seconds
 
 const TARGET_SPACING = 600 // every 10 minutes
 


### PR DESCRIPTION
Difficulty retarget changed from 2016 blocks to 144 blocks.