### PR TITLE
Change diff recalc to 144 block SMA, 2016 period

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -19,9 +19,13 @@ const MAX_FUTURE_SECONDS = 2 * 60 * 60 // 2 hours
 
 const MAX_MONEY = 21000000 * CRUZBITS_PER_CRUZ
 
-const RETARGET_INTERVAL = 2016 // 2 weeks in blocks
+const DIFF_FORK_TARGET = 30240 // block height to switch to new diff algo
+
+const RETARGET_INTERVAL = 144 // 1 day in blocks
 
 const RETARGET_TIME = 1209600 // 2 weeks in seconds
+
+const RETARGET_DEPTH = 2016 // 2 weeks in blocks
 
 const TARGET_SPACING = 600 // every 10 minutes
 

--- a/processor.go
+++ b/processor.go
@@ -681,15 +681,23 @@ func BlockCreationReward(height int64) int64 {
 
 // Compute expected target of the current block
 func computeTarget(prevHeader *BlockHeader, blockStore BlockStorage) (BlockID, error) {
-	if (prevHeader.Height+1)%RETARGET_INTERVAL != 0 {
-		// not 2016th block, use previous block's value
-		return prevHeader.Target, nil
+	if prevHeader.Height < DIFF_FORK_TARGET {
+		// original diff algo
+		if (prevHeader.Height + 1)%RETARGET_DEPTH != 0 {
+			// not 2016th block, use previous block's value
+			return prevHeader.Target, nil
+		}
+	} else {
+		if (prevHeader.Height+1)%RETARGET_INTERVAL != 0 {
+			// not a multiple of 144 blocks, use previous value
+			return prevHeader.Target, nil
+		}
 	}
 
 	// defend against time warp attack
-	blocksToGoBack := RETARGET_INTERVAL - 1
-	if (prevHeader.Height + 1) != RETARGET_INTERVAL {
-		blocksToGoBack = RETARGET_INTERVAL
+	blocksToGoBack := RETARGET_DEPTH - 1
+	if (prevHeader.Height + 1) != RETARGET_DEPTH {
+		blocksToGoBack = RETARGET_DEPTH
 	}
 
 	// walk back to the first block of the interval


### PR DESCRIPTION
Increase diff retarget frequency to 144 blocks (approximately one day), while
still using the previous 2016 blocks for calculation.